### PR TITLE
Supporting spaced names and empty payload

### DIFF
--- a/JustTrack/JEEventsGenerator/main.swift
+++ b/JustTrack/JEEventsGenerator/main.swift
@@ -158,7 +158,7 @@ func generateStructs(_ events: [String : AnyObject]) throws -> NSString {
     var structsArray: [String] = Array()
 
     guard events.keys.count > 0 else {
-        throw JEStructsGeneratorError.eventsArrayNotFound
+        throw JEStructsGeneratorError.eventsArrayEmpty
     }
 
     for eventName in events.keys {

--- a/JustTrack/JEEventsGenerator/main.swift
+++ b/JustTrack/JEEventsGenerator/main.swift
@@ -271,7 +271,7 @@ private func generateEventKeyValueChain(_ keys: [String]) -> String {
         return ":"
     } else {
         return keys.flatMap { key in
-            return "k\(swiftyClassName(for: key)): \(key) as NSObject"
+            return "k\(swiftyClassName(for: key)): \(swiftyPropertyName(for: key)) as NSObject"
             }.joined(separator: ", ")
     }
 }


### PR DESCRIPTION
### **The problem**
Many analytics tools provide some flexibility naming events and attributes. With this in mind, this PR is intended to add this feature to JustTracker.

### **Bonus**
Additionally, I've removed all `for index in 0...keys.count-1` and some forced unwraps in order to improve code safety. Now, if the user doesn't provide a payload (what isn't so uncommon), the generator will do the magic without break 😃

### **Result**
For the Events.plist in the end of this description we have this generated class:
```swift
@objc public class JEEventMyCoolEvent:NSObject,JEEvent {

    //JEEvent protocol
    public let name: String = "My Cool Event"

    public var payload: Payload {
        return [kCoolerSpacedAttribute: coolerSpacedAttribute as NSObject, kAnotherAttribute: anotherAttribute as NSObject, kAttribute: attribute as NSObject, kGiveMeSpaAAACe: giveMeSpaAAACe as NSObject]
    }

    public var registeredTrackers: [String] {
        return ["console", "tracker2"]
    }

    //keys
    private let kCoolerSpacedAttribute = "Cooler Spaced Attribute"
    private let kAnotherAttribute = "anotherAttribute"
    private let kAttribute = "Attribute"
    private let kGiveMeSpaAAACe = "give me spa a  a   a    ce"

    var coolerSpacedAttribute: String = ""
    var anotherAttribute: String = ""
    var attribute: String = ""
    var giveMeSpaAAACe: String = ""

    public init(coolerSpacedAttribute: String, anotherAttribute: String, attribute: String, giveMeSpaAAACe: String) {
        super.init()
        self.coolerSpacedAttribute = coolerSpacedAttribute
        self.anotherAttribute = anotherAttribute
        self.attribute = attribute
        self.giveMeSpaAAACe = giveMeSpaAAACe
    }
}
```
Without this PR, the result is:

```swift
@objc public class JEEventMy Cool Event:NSObject,JEEvent {

    //JEEvent protocol
    public let name: String = "My Cool Event"

    public var payload: Payload {
        return [kCooler Spaced Attribute : Cooler Spaced Attribute as NSObject, kAnotherAttribute : anotherAttribute as NSObject, kAttribute : Attribute as NSObject, kGive me spa a  a   a    ce : give me spa a  a   a    ce as NSObject]
    }

    public var registeredTrackers: [String] {
        return ["console", "tracker2"]
    }

    //keys
    private let kCooler Spaced Attribute = "Cooler Spaced Attribute"
    private let kAnotherAttribute = "anotherAttribute"
    private let kAttribute = "Attribute"
    private let kGive me spa a  a   a    ce = "give me spa a  a   a    ce"

    var Cooler Spaced Attribute: String = ""
    var anotherAttribute: String = ""
    var Attribute: String = ""
    var give me spa a  a   a    ce: String = ""

    public init(Cooler Spaced Attribute: String, anotherAttribute: String, Attribute: String, give me spa a  a   a    ce: String) {
        super.init()
        self.Cooler Spaced Attribute = Cooler Spaced Attribute
        self.anotherAttribute = anotherAttribute
        self.Attribute = Attribute
        self.give me spa a  a   a    ce = give me spa a  a   a    ce
    }
}
```

Events.plist:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>events</key>
	<dict>
		<key>My Cool Event</key>
		<dict>
			<key>registeredTrackers</key>
			<array>
				<string>console</string>
				<string>tracker2</string>
			</array>
			<key>payloadKeys</key>
			<array>
				<string>Cooler Spaced Attribute</string>
				<string>anotherAttribute</string>
				<string>Attribute</string>
				<string>give me spa a  a   a    ce</string>
			</array>
		</dict>		
	</dict>
</dict>
</plist>
```