### PR TITLE
MT-1614: v3 - Remove the Configuration typealias and the init(configu…

### DIFF
--- a/Example/Pods/Local Podspecs/JustTrack.podspec.json
+++ b/Example/Pods/Local Podspecs/JustTrack.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "JustTrack",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "summary": "The Just Eat solution to better manage the analytics tracking on iOS and improve the relationship with your BI team.",
   "description": "At Just Eat, tracking events is a fundamental part of our business analysis and the information we collect informs our technical and strategic decisions. To collect the information required we needed a flexible, future-proof and easy to use tracking system that enables us to add, remove and swap the underlying integrations with analytical systems and services with minimal impact on our applications' code. We also wanted to solve the problem of keeping the required event metadata up-to-date whenever the requirements change.\nJustTrack is the event tracking solution we built for that.",
   "homepage": "https://github.com/JustEat/JustTrack",
@@ -15,7 +15,7 @@
   },
   "source": {
     "git": "https://github.com/justeat/JustTrack.git",
-    "tag": "2.0.0"
+    "tag": "3.0.0"
   },
   "social_media_url": "https://twitter.com/justeat_tech",
   "platforms": {

--- a/Example/Tests/Info.plist
+++ b/Example/Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.9</string>
+	<string>3.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Example/Tests/TrackerTests.swift
+++ b/Example/Tests/TrackerTests.swift
@@ -26,8 +26,8 @@ class TrackerTests: XCTestCase {
             print("[trackerService] [\(logLevel.rawValue)] \(logString)")
         }
         
-        tracker1  = MockTracker(configuration: nil)
-        tracker2 = SomeOtherMockTracker(configuration: nil)
+        tracker1  = MockTracker()
+        tracker2 = SomeOtherMockTracker()
     }
     
     // MARK: - Teardown

--- a/Example/Tests/Trackers.swift
+++ b/Example/Tests/Trackers.swift
@@ -9,12 +9,9 @@ import Foundation
 import JustTrack
 
 final class MockTracker: NSObject, JETracker {
-    let name: String
+    let name =  "MockTracker"
     var didTrackEvent = false
     
-    public init(configuration: Configuration?) {
-        self.name = "MockTracker"
-    }
     open func trackEvent(_ name: String, payload: Payload, completion: (_ success: Bool) -> Void) {
         didTrackEvent = true
         completion(true)
@@ -22,12 +19,9 @@ final class MockTracker: NSObject, JETracker {
 }
 
 final class SomeOtherMockTracker: NSObject, JETracker {
-    let name: String
+    let name = "SomeOtherMockTracker"
     var didTrackEvent = false
     
-    public init(configuration: Configuration?) {
-        self.name = "SomeOtherMockTracker"
-    }
     open func trackEvent(_ name: String, payload: Payload, completion: (_ success: Bool) -> Void) {
         didTrackEvent = true
         completion(true)

--- a/JustTrack.podspec
+++ b/JustTrack.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'JustTrack'
-  s.version          = '2.0.1'
+  s.version          = '3.0.0'
   s.summary          = 'The Just Eat solution to better manage the analytics tracking on iOS and improve the relationship with your BI team.'
 
   s.description      = <<-DESC

--- a/JustTrack/Classes/JustTrack/JETracker.swift
+++ b/JustTrack/Classes/JustTrack/JETracker.swift
@@ -6,10 +6,7 @@
 
 import Foundation
 
-public typealias Configuration = [String : String]
-
 @objc public protocol JETracker {
     var name: String { get }
-    init(configuration: Configuration?)
     func trackEvent(_ name: String, payload: Payload, completion: (_ success: Bool) -> Void )
 }

--- a/JustTrack/Classes/JustTrack/JETracking.swift
+++ b/JustTrack/Classes/JustTrack/JETracking.swift
@@ -100,7 +100,7 @@ import Foundation
         
         switch type {
         case .consoleLogger:
-            tracker = JETrackerConsole(configuration: nil)
+            tracker = JETrackerConsole()
             break
         }
         
@@ -131,7 +131,7 @@ import Foundation
         //TODO: validate event
         if eventIsValid(internalEvent) == false {
             
-            JTLog("Invalid event \(event)", level: JETrackingLogLevel.error)
+            JTLog("Invalid event \(event)", level: .error)
             return false
         }
         
@@ -152,7 +152,7 @@ import Foundation
                 self.operationQueue.addOperation(operation)
             }
             else {
-                JTLog("Trying to track and event  (\(event.name)) in an invalid Tracker (\(trackerName))", level: JETrackingLogLevel.error)
+                JTLog("Trying to track and event  (\(event.name)) in an invalid Tracker (\(trackerName))", level: .error)
             }
         }
         
@@ -166,11 +166,11 @@ import Foundation
             return
         }
         
-        JTLog("Enabling tracker...", level: JETrackingLogLevel.info)
+        JTLog("Enabling tracker...", level: .info)
         
         let restoredEventsCount = self.restoreUncompletedTracking()
         if restoredEventsCount > 0 {
-            JTLog("\(restoredEventsCount) events restored", level: JETrackingLogLevel.info)
+            JTLog("\(restoredEventsCount) events restored", level: .info)
         }
     }
     

--- a/JustTrack/Classes/JustTrack/Trackers/JETrackerConsole.swift
+++ b/JustTrack/Classes/JustTrack/Trackers/JETrackerConsole.swift
@@ -9,14 +9,12 @@ import Foundation
 @objcMembers
 class JETrackerConsole: NSObject, JETracker {
     
-    var name: String
+    // MARK: - JETracker protocol implementation
     
-    required init(configuration: Configuration?) {
-        self.name = "console"
-    }
+    let name = "console"
     
     func trackEvent(_ name: String, payload: Payload, completion: (_ success: Bool) -> Void) {
-         print("[\(self.name)] ☞ Event: \(name) \(payload)")
+        print("[\(self.name)] ☞ Event: \(name) \(payload)")
         completion(true)
     }
 }

--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ For any feature request, bug report or question please use the [Issues](https://
 * Events can be sent to multiple destinations (called *Trackers*) at the same time.
 * Custom *Trackers* are easy to create and use.
 
-## Usage
-
 ## Installation
 
 JustTrack is available through [CocoaPods](http://cocoapods.org). To install it, simply add the following line to your Podfile:
@@ -57,6 +55,7 @@ Where:
 * ```"${SRCROOT}/JustTrack/TrackingEvents.swift"``` Is the destination file for the automatically generated Swift code.
 
 _**NOTE:** Consider giving this script a meaningful name (e.g. "Name: JustTrack Events Generation")_
+
 
 ## Usage
 
@@ -186,6 +185,40 @@ A Tracker is an object implementing the **JETracker** protocol and is loaded usi
 * [ ] JEFacebookTraker (not yet implemented)
 * [ ] ~~JEGoogleAnalyticsTraker~~ (not yet implemented, Google's pods can't be used as a dependency in a pod)
 * [ ] ~~JETrakerFirebase~~ (not yet implemented, Google's pods can't be used as a dependency in a pod)
+
+
+
+
+## Upgrading to v3.0
+
+In version 3.0 of JustTrack the Configuration class has been removed from the JETracker protocol.
+
+If your client code uses Objective-C then your code should continue to function without changes when upgrading.
+
+If your client code uses Swift then then you have two options.
+
+Option 1) The simplest way to upgrade to v3.0 of the SDK is to reintroduce the Configuration typealias in your client code as follows:
+
+```
+public typealias Configuration = [String : String]
+```
+
+Option 2) Replace your initialisers with an equivalent where your arguments are passed in a strongly typed manner.  For example, this old init method....
+
+```
+public init(configuration: Configuration) {
+    super.init()
+    self.token = conifiguration[TokenKey]
+}
+```
+might become...
+
+```
+public init(token: String) {
+    super.init()
+    self.token = token
+}
+```
 
 ## License
 


### PR DESCRIPTION
…ration: Configuration) method.  The configuration is an implementation detail of any concrete JETracker classes and is not of any concern to the protocol.  Also it would be far better if the concrete classes were to define their dependencies with strongly typed parameters rather than a stringly typed dictionary.

https://jira.just-eat.net/browse/MT-1614