### PR TITLE
Support Further Data Types and Dictionary Encoding within Array of Objects Payload

### DIFF
--- a/Example/JustTrack.xcodeproj/project.pbxproj
+++ b/Example/JustTrack.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		230EB93C2681395300BF6162 /* EventObjectInitAssignTemplate.jet in CopyFiles */ = {isa = PBXBuildFile; fileRef = 231FC37E266E7F3600FFBEDB /* EventObjectInitAssignTemplate.jet */; };
+		230EB93D2681395300BF6162 /* EventObjectInitTemplate.jet in CopyFiles */ = {isa = PBXBuildFile; fileRef = 231FC37A266E74A800FFBEDB /* EventObjectInitTemplate.jet */; };
+		230EB93E2681395300BF6162 /* EventObjectInitParam.jet in CopyFiles */ = {isa = PBXBuildFile; fileRef = 231FC37C266E74B900FFBEDB /* EventObjectInitParam.jet */; };
 		231FC37B266E74A800FFBEDB /* EventObjectInitTemplate.jet in Resources */ = {isa = PBXBuildFile; fileRef = 231FC37A266E74A800FFBEDB /* EventObjectInitTemplate.jet */; };
 		231FC37D266E74B900FFBEDB /* EventObjectInitParam.jet in Sources */ = {isa = PBXBuildFile; fileRef = 231FC37C266E74B900FFBEDB /* EventObjectInitParam.jet */; };
 		231FC37F266E7F3600FFBEDB /* EventObjectInitAssignTemplate.jet in Resources */ = {isa = PBXBuildFile; fileRef = 231FC37E266E7F3600FFBEDB /* EventObjectInitAssignTemplate.jet */; };
@@ -40,6 +43,9 @@
 			dstPath = "";
 			dstSubfolderSpec = 7;
 			files = (
+				230EB93C2681395300BF6162 /* EventObjectInitAssignTemplate.jet in CopyFiles */,
+				230EB93D2681395300BF6162 /* EventObjectInitTemplate.jet in CopyFiles */,
+				230EB93E2681395300BF6162 /* EventObjectInitParam.jet in CopyFiles */,
 				23CCE234265F0AE9007B5F64 /* EventObjectKeyVarTemplate.jet in CopyFiles */,
 				23CCE1EB265D4BF1007B5F64 /* EventObjectStructTemplate.jet in CopyFiles */,
 				C8566BED1E293FA100CC27E3 /* EventInitAssignTemplate.jet in CopyFiles */,

--- a/Example/JustTrack/Events.plist
+++ b/Example/JustTrack/Events.plist
@@ -25,6 +25,8 @@
 					<array>
 						<string>item_name</string>
 						<string>item_number_int</string>
+						<string>Item_price_double</string>
+						<string>item_value_bool</string>
 					</array>
 				</dict>
 				<dict>

--- a/Example/JustTrack/Events.plist
+++ b/Example/JustTrack/Events.plist
@@ -25,7 +25,7 @@
 					<array>
 						<string>item_name</string>
 						<string>item_number_int</string>
-						<string>Item_price_double</string>
+						<string>item_price_double</string>
 						<string>item_value_bool</string>
 					</array>
 				</dict>

--- a/Example/JustTrack/Events.plist
+++ b/Example/JustTrack/Events.plist
@@ -24,7 +24,7 @@
 					<key>objectPayloadKeys</key>
 					<array>
 						<string>item_name</string>
-						<string>item_number</string>
+						<string>item_number_int</string>
 					</array>
 				</dict>
 				<dict>

--- a/Example/JustTrack/TrackingEvents.swift
+++ b/Example/JustTrack/TrackingEvents.swift
@@ -39,7 +39,7 @@ public class EventExample: Event {
 import Foundation
 import JustTrack
 
-public class EventViewScreen: Event  {
+public class EventViewScreen: Event {
 
     public let name: String = "view_screen"
     
@@ -64,10 +64,10 @@ public class EventViewScreen: Event  {
     
     
 
-    public var screenName = "" 
-    public var screenData = "" 
-    public var screenDataVar = "" 
-    public var screenDataVarSetting = "" 
+    public var screenName = ""
+    public var screenData = ""
+    public var screenDataVar = ""
+    public var screenDataVarSetting = ""
     
 
     public init(screenName: String,
@@ -80,13 +80,12 @@ public class EventViewScreen: Event  {
         self.screenDataVarSetting = screenDataVarSetting
     }
 }
-public class EventExample: Event  {
+public class EventExample: Event {
 
     public let name: String = "example_name"
     
     public struct TestObject: Equatable, Codable {
-
-        public var itemName = "" 
+        public var itemName = ""
         public var itemNumber = 0        
         
         public init(itemName: String,
@@ -103,9 +102,8 @@ public class EventExample: Event  {
     }
 
     public struct SecondTestObject: Equatable, Codable {
-
-        public var itemName = "" 
-        public var itemNumberTest = ""         
+        public var itemName = ""
+        public var itemNumberTest = ""        
         
         public init(itemName: String,
                     itemNumberTest: String) {
@@ -143,9 +141,9 @@ public class EventExample: Event  {
     private let kTestObject = "testObject"
     private let kSecondTestObject = "secondTestObject"
 
-    public var test1 = "" 
-    public var test2 = "" 
-    public var test3 = "" 
+    public var test1 = ""
+    public var test2 = ""
+    public var test3 = ""
     public var testObject: [TestObject]
     public var secondTestObject: [SecondTestObject]
 
@@ -161,7 +159,7 @@ public class EventExample: Event  {
         self.secondTestObject = secondTestObject
     }
 }
-public class EventUser: Event  {
+public class EventUser: Event {
 
     public let name: String = "User"
     
@@ -184,9 +182,9 @@ public class EventUser: Event  {
     
     
 
-    public var action = "" 
-    public var response = "" 
-    public var extra = "" 
+    public var action = ""
+    public var response = ""
+    public var extra = ""
     
 
     public init(action: String,
@@ -197,7 +195,7 @@ public class EventUser: Event  {
         self.extra = extra
     }
 }
-public class EventTap: Event  {
+public class EventTap: Event {
 
     public let name: String = "Tap"
     
@@ -216,14 +214,14 @@ public class EventTap: Event  {
     
     
 
-    public var elementName = "" 
+    public var elementName = ""
     
 
     public init(elementName: String) {
         self.elementName = elementName
     }
 }
-public class EventNoPayload: Event  {
+public class EventNoPayload: Event {
 
     public let name: String = "NoPayload"
     

--- a/Example/JustTrack/TrackingEvents.swift
+++ b/Example/JustTrack/TrackingEvents.swift
@@ -39,7 +39,7 @@ public class EventExample: Event {
 import Foundation
 import JustTrack
 
-public class EventViewScreen: Event {
+public class EventViewScreen: Event  {
 
     public let name: String = "view_screen"
     
@@ -64,10 +64,10 @@ public class EventViewScreen: Event {
     
     
 
-    public var screenName = ""
-    public var screenData = ""
-    public var screenDataVar = ""
-    public var screenDataVarSetting = ""
+    public var screenName = "" 
+    public var screenData = "" 
+    public var screenDataVar = "" 
+    public var screenDataVarSetting = "" 
     
 
     public init(screenName: String,
@@ -80,30 +80,44 @@ public class EventViewScreen: Event {
         self.screenDataVarSetting = screenDataVarSetting
     }
 }
-public class EventExample: Event {
+public class EventExample: Event  {
 
     public let name: String = "example_name"
     
-    public struct TestObject: Equatable {
-        public var itemName = ""
-        public var itemNumber = ""        
+    public struct TestObject: Equatable, Codable {
+
+        public var itemName = "" 
+        public var itemNumber = 0        
         
         public init(itemName: String,
-                    itemNumber: String) {
+                    itemNumber: Int) {
             self.itemName = itemName
             self.itemNumber = itemNumber
         }        
+        
+        var asDict: [String: Any] {
+            ["item_name" : itemName,
+             "item_number" : itemNumber]            
+        }
+        
     }
 
-    public struct SecondTestObject: Equatable {
-        public var itemName = ""
-        public var itemNumberTest = ""        
+    public struct SecondTestObject: Equatable, Codable {
+
+        public var itemName = "" 
+        public var itemNumberTest = ""         
         
         public init(itemName: String,
                     itemNumberTest: String) {
             self.itemName = itemName
             self.itemNumberTest = itemNumberTest
         }        
+        
+        var asDict: [String: Any] {
+            ["item_name" : itemName,
+             "item_number_test" : itemNumberTest]            
+        }
+        
     }
       
 
@@ -113,8 +127,8 @@ public class EventExample: Event {
             kTest2: test2 == "" ? NSNull() : test2 as NSString, 
             kTest3: test3 == "" ? NSNull() : test3 as NSString,
         
-            kTestObject: testObject == [] ? NSNull() : testObject as [TestObject] , 
-            kSecondTestObject: secondTestObject == [] ? NSNull() : secondTestObject as [SecondTestObject] 
+            kTestObject: testObject == [] ? NSNull() : testObject.map { $0.asDict }, 
+            kSecondTestObject: secondTestObject == [] ? NSNull() : secondTestObject.map { $0.asDict }
         ]
     }
 
@@ -129,9 +143,9 @@ public class EventExample: Event {
     private let kTestObject = "testObject"
     private let kSecondTestObject = "secondTestObject"
 
-    public var test1 = ""
-    public var test2 = ""
-    public var test3 = ""
+    public var test1 = "" 
+    public var test2 = "" 
+    public var test3 = "" 
     public var testObject: [TestObject]
     public var secondTestObject: [SecondTestObject]
 
@@ -147,7 +161,7 @@ public class EventExample: Event {
         self.secondTestObject = secondTestObject
     }
 }
-public class EventUser: Event {
+public class EventUser: Event  {
 
     public let name: String = "User"
     
@@ -170,9 +184,9 @@ public class EventUser: Event {
     
     
 
-    public var action = ""
-    public var response = ""
-    public var extra = ""
+    public var action = "" 
+    public var response = "" 
+    public var extra = "" 
     
 
     public init(action: String,
@@ -183,7 +197,7 @@ public class EventUser: Event {
         self.extra = extra
     }
 }
-public class EventTap: Event {
+public class EventTap: Event  {
 
     public let name: String = "Tap"
     
@@ -202,14 +216,14 @@ public class EventTap: Event {
     
     
 
-    public var elementName = ""
+    public var elementName = "" 
     
 
     public init(elementName: String) {
         self.elementName = elementName
     }
 }
-public class EventNoPayload: Event {
+public class EventNoPayload: Event  {
 
     public let name: String = "NoPayload"
     

--- a/Example/JustTrack/TrackingEvents.swift
+++ b/Example/JustTrack/TrackingEvents.swift
@@ -102,10 +102,12 @@ public class EventExample: Event {
         }        
         
         var asDict: [String: Any] {
-            ["item_name" : itemName,
+            [
+             "item_name" : itemName,
              "item_number" : itemNumber,
              "item_price" : itemPrice,
-             "item_value" : itemValue]            
+             "item_value" : itemValue
+            ]            
         }
         
     }
@@ -122,8 +124,10 @@ public class EventExample: Event {
         }        
         
         var asDict: [String: Any] {
-            ["item_name" : itemName,
-             "item_number_test" : itemNumberTest]            
+            [
+             "item_name" : itemName,
+             "item_number_test" : itemNumberTest
+            ]            
         }
         
     }

--- a/Example/JustTrack/TrackingEvents.swift
+++ b/Example/JustTrack/TrackingEvents.swift
@@ -88,23 +88,23 @@ public class EventExample: Event {
 
         public var itemName = ""
         public var itemNumber = 0
-        public var ItemPrice = 0.0
+        public var itemPrice = 0.0
         public var itemValue = false        
         
         public init(itemName: String,
                     itemNumber: Int,
-                    ItemPrice: Double,
+                    itemPrice: Double,
                     itemValue: Bool) {
             self.itemName = itemName
             self.itemNumber = itemNumber
-            self.ItemPrice = ItemPrice
+            self.itemPrice = itemPrice
             self.itemValue = itemValue
         }        
         
         var asDict: [String: Any] {
             ["item_name" : itemName,
              "item_number" : itemNumber,
-             "Item_price" : ItemPrice,
+             "item_price" : itemPrice,
              "item_value" : itemValue]            
         }
         

--- a/Example/JustTrack/TrackingEvents.swift
+++ b/Example/JustTrack/TrackingEvents.swift
@@ -85,23 +85,33 @@ public class EventExample: Event {
     public let name: String = "example_name"
     
     public struct TestObject: Equatable, Codable {
+
         public var itemName = ""
-        public var itemNumber = 0        
+        public var itemNumber = 0
+        public var ItemPrice = 0.0
+        public var itemValue = false        
         
         public init(itemName: String,
-                    itemNumber: Int) {
+                    itemNumber: Int,
+                    ItemPrice: Double,
+                    itemValue: Bool) {
             self.itemName = itemName
             self.itemNumber = itemNumber
+            self.ItemPrice = ItemPrice
+            self.itemValue = itemValue
         }        
         
         var asDict: [String: Any] {
             ["item_name" : itemName,
-             "item_number" : itemNumber]            
+             "item_number" : itemNumber,
+             "Item_price" : ItemPrice,
+             "item_value" : itemValue]            
         }
         
     }
 
     public struct SecondTestObject: Equatable, Codable {
+
         public var itemName = ""
         public var itemNumberTest = ""        
         

--- a/JustTrack.podspec
+++ b/JustTrack.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'JustTrack'
-  s.version          = '4.1.0'
+  s.version          = '4.2.0'
   s.summary          = 'The Just Eat solution to better manage the analytics tracking on iOS and improve the relationship with your BI team.'
 
   s.description      = <<-DESC

--- a/JustTrack/EventsGenerator/EventKeyVarTemplate.jet
+++ b/JustTrack/EventsGenerator/EventKeyVarTemplate.jet
@@ -1,1 +1,1 @@
-public var <*key_name*> = ""
+public var <*key_name*>

--- a/JustTrack/EventsGenerator/EventObjectStructTemplate.jet
+++ b/JustTrack/EventsGenerator/EventObjectStructTemplate.jet
@@ -1,5 +1,4 @@
 public struct <*object_name*>: Equatable, Codable {
-
         <*object_parameter_list*>
         
         

--- a/JustTrack/EventsGenerator/EventObjectStructTemplate.jet
+++ b/JustTrack/EventsGenerator/EventObjectStructTemplate.jet
@@ -1,7 +1,16 @@
-public struct <*object_name*>: Equatable {
+public struct <*object_name*>: Equatable, Codable {
+
         <*object_parameter_list*>
         
         
         <*event_object_init*>
         
+        
+        var asDict: [String: Any] {
+            <*dictionary_parameter_list*>
+            
+        }
+        
     }
+    
+

--- a/JustTrack/EventsGenerator/EventObjectStructTemplate.jet
+++ b/JustTrack/EventsGenerator/EventObjectStructTemplate.jet
@@ -1,4 +1,5 @@
 public struct <*object_name*>: Equatable, Codable {
+
         <*object_parameter_list*>
         
         

--- a/JustTrack/EventsGenerator/EventTemplate.jet
+++ b/JustTrack/EventsGenerator/EventTemplate.jet
@@ -21,3 +21,4 @@ public class Event<*!event*>: Event {
     <*event_init*>
 }
 
+

--- a/JustTrack/EventsGenerator/EventTemplate.jet
+++ b/JustTrack/EventsGenerator/EventTemplate.jet
@@ -1,4 +1,4 @@
-public class Event<*!event*>: Event  {
+public class Event<*!event*>: Event {
 
     public let name: String = "<*name*>"
     <*event_ObjectStructs*>

--- a/JustTrack/EventsGenerator/EventTemplate.jet
+++ b/JustTrack/EventsGenerator/EventTemplate.jet
@@ -1,4 +1,4 @@
-public class Event<*!event*>: Event {
+public class Event<*!event*>: Event  {
 
     public let name: String = "<*name*>"
     <*event_ObjectStructs*>

--- a/JustTrack/EventsGenerator/main.swift
+++ b/JustTrack/EventsGenerator/main.swift
@@ -459,7 +459,7 @@ func generateObjectDictionaryFunction(objectParameters: [String]) -> String {
         structureResult = resultArray.joined(separator: "\n")
     }
     
-    structureResult = "[" + structureResult + "]"
+    structureResult = "[\n             " + structureResult + "\n            ]"
     
     return structureResult
 }

--- a/JustTrack/EventsGenerator/main.swift
+++ b/JustTrack/EventsGenerator/main.swift
@@ -286,7 +286,7 @@ private func generateEvents(_ events: [String : AnyObject]) throws -> NSString {
          let key2 : String
          */
         
-        let eventKeysVars: String = try generateKeyVariables(cleanKeys, keyType: "eventKey")
+        let eventKeysVars: String = try generateKeyVariables(cleanKeys)
         let objectKeysVars: String = try generateObjectKeysVariables(objectNames)
         structString = replacePlaceholder(structString, placeholder: "<*\(EventTemplatePlaceholder.keysVars.rawValue)*>", value: eventKeysVars, placeholderType: "routine")
         structString = replacePlaceholder(structString, placeholder: "<*\(EventTemplatePlaceholder.objectKeysVars.rawValue)*>", value: objectKeysVars, placeholderType: "routine")
@@ -340,7 +340,7 @@ private func replacePlaceholder(_ original: String, placeholder: String, value: 
         case "routine":
             return original.replacingOccurrences(of: placeholder, with: valueToReplace)
         case "eventStringParameter":
-            return original.replacingOccurrences(of: placeholder, with: valueToReplace + " = " + "\"\" ")
+            return original.replacingOccurrences(of: placeholder, with: valueToReplace + " = " + "\"\"")
         case "eventIntParameter":
             return original.replacingOccurrences(of: placeholder, with: valueToReplace + " = 0")
         case "eventAssignedStringParameter":
@@ -481,7 +481,7 @@ private func generateEventKeysNames(_ keys: [String]) throws -> String {
     return resultArray.count > 0 ? resultArray.joined(separator: "\n    ") : ""
 }
 
-private func generateKeyVariables(_ keys: [String], keyType: String) throws -> String {
+private func generateKeyVariables(_ keys: [String]) throws -> String {
     
     let structVarTemplate: String = try stringFromTemplate(EventTemplate.keyVar.rawValue)
         
@@ -491,14 +491,7 @@ private func generateKeyVariables(_ keys: [String], keyType: String) throws -> S
         resultArray.append(structVarString)
     }
     
-    switch keyType {
-        case "eventKey":
-            return resultArray.count > 0 ? resultArray.joined(separator: "\n    ") : ""
-        case "objectKey":
-            return resultArray.count > 0 ? resultArray.joined(separator: "\n        ") : ""
-        default:
-            return resultArray.count > 0 ? resultArray.joined(separator: "\n    ") : ""
-    }
+    return resultArray.count > 0 ? resultArray.joined(separator: "\n    ") : ""
 }
 
 
@@ -509,7 +502,7 @@ private func generateStructKeyVariables(_ keys: [String], keyType: String) throw
     var resultArray: [String] = Array()
     
     for keyString in keys {
-        if keyString.contains("int") {
+        if keyString.contains("_int") {
             let paramResultString = replacePlaceholder(structVarTemplate, placeholder: "<*\(EventTemplatePlaceholder.keyName.rawValue)*>", value: sanitised(keyString), placeholderType: "eventIntParameter")
             resultArray.append(paramResultString)
         }

--- a/JustTrack/EventsGenerator/main.swift
+++ b/JustTrack/EventsGenerator/main.swift
@@ -415,7 +415,7 @@ func generateObjectStructs(_ objects: [Any]) throws -> String {
         let objectKeysVars: String = try generateStructKeyVariables(objectParameters, keyType: "objectKey")
         structObjectKeyString = replacePlaceholder(structObjectKeyString, placeholder: "<*\(EventTemplatePlaceholder.objectStructParams.rawValue)*>\n", value: objectKeysVars, placeholderType: "routine")
         
-        let objectKeysInit: String = try generateEventObjectInit(objectParameters, objectParameters)
+        let objectKeysInit: String = try generateEventObjectInit(objectParameters)
         
         structObjectKeyString = replacePlaceholder(structObjectKeyString, placeholder: "<*\(EventTemplatePlaceholder.eventObjectInit.rawValue)*>\n", value: objectKeysInit, placeholderType: "routine")
         
@@ -594,7 +594,7 @@ private func generateEventInit(_ keys: [String], _ objectKeys: [String]) throws 
     return initTemplateString
 }
 
-private func generateEventObjectInit(_ keys: [String], _ objectKeys: [String]) throws -> String {
+private func generateEventObjectInit(_ keys: [String]) throws -> String {
     
     if keys.count == 0 {
         return "//MARK: Payload not configured"

--- a/JustTrack/UnitTests/EventInternalTests.swift
+++ b/JustTrack/UnitTests/EventInternalTests.swift
@@ -31,11 +31,17 @@ class EventInternalTests: XCTestCase {
        struct Items: Equatable {
             public var itemName = ""
             public var itemNumber = 0
+            public var itemDouble = 0.0
+            public var itemBool = false
             
             public init(itemName: String,
-                        itemNumber: Int) {
+                        itemNumber: Int,
+                        itemDouble: Double,
+                        itemBool: Bool) {
                 self.itemName = itemName
                 self.itemNumber = itemNumber
+                self.itemDouble = itemDouble
+                self.itemBool = itemBool
             }
         }
         

--- a/JustTrack/UnitTests/EventInternalTests.swift
+++ b/JustTrack/UnitTests/EventInternalTests.swift
@@ -30,10 +30,10 @@ class EventInternalTests: XCTestCase {
         
        struct Items: Equatable {
             public var itemName = ""
-            public var itemNumber = ""
+            public var itemNumber = 0
             
             public init(itemName: String,
-                        itemNumber: String) {
+                        itemNumber: Int) {
                 self.itemName = itemName
                 self.itemNumber = itemNumber
             }

--- a/README.md
+++ b/README.md
@@ -234,10 +234,23 @@ Another change made within version 4.0 is the preservation of order within the a
 
 ### Facilitating an array of objects
 
-**JustTrack** now allows for the implementation of an array of objects as part of the payload. In order to implement such events, create a new item of type Dictionary and adhere to the objectPayloadKeys notation as detailed by the example event. An array of objects also supports integer values. To add these to your array of objects, simply append `_int` to the end of the value as follows: 
+**JustTrack** now allows for the implementation of an array of objects as part of the payload. In order to implement such events, create a new item of type Dictionary and adhere to the objectPayloadKeys notation as detailed by the example event. An array of objects also supports different data types. To add these to your array of objectst, simply append the varable type to the end of the value as follows: 
+
+Integers:
 
 ```
 itemnumber_int
+```
+
+Double:
+
+```
+itemPrice_double
+```
+
+Booleans:
+```
+itemAvaliable_bool
 ```
 
 ## Upgrading to v3.0

--- a/README.md
+++ b/README.md
@@ -234,7 +234,11 @@ Another change made within version 4.0 is the preservation of order within the a
 
 ### Facilitating an array of objects
 
-**JustTrack** now allows for the implementation of an array of objects as part of the payload. In order to implement such events, create a new item of type Dictionary and adhere to the objectPayloadKeys notation as detailed by the example event.
+**JustTrack** now allows for the implementation of an array of objects as part of the payload. In order to implement such events, create a new item of type Dictionary and adhere to the objectPayloadKeys notation as detailed by the example event. An array of objects also supports integer values. To add these to your array of objects, simply append `_int` to the end of the value as follows: 
+
+```
+itemnumber_int
+```
 
 ## Upgrading to v3.0
 

--- a/README.md
+++ b/README.md
@@ -234,12 +234,12 @@ Another change made within version 4.0 is the preservation of order within the a
 
 ### Facilitating an array of objects
 
-**JustTrack** now allows for the implementation of an array of objects as part of the payload. In order to implement such events, create a new item of type Dictionary and adhere to the objectPayloadKeys notation as detailed by the example event. An array of objects also supports different data types. To add these to your array of objectst, simply append the varable type to the end of the value as follows: 
+**JustTrack** now allows for the implementation of an array of objects as part of the payload. In order to implement such events, create a new item of type Dictionary and adhere to the objectPayloadKeys notation as detailed by the example event. An array of objects also supports different data types. To add these to your array of objects, simply append the varable type to the end of the value as follows: 
 
 Integers:
 
 ```
-itemnumber_int
+itemNumber_int
 ```
 
 Double:
@@ -249,6 +249,7 @@ itemPrice_double
 ```
 
 Booleans:
+
 ```
 itemAvaliable_bool
 ```

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ itemPrice_double
 Booleans:
 
 ```
-itemAvaliable_bool
+itemAvailable_bool
 ```
 
 ## Upgrading to v3.0


### PR DESCRIPTION
As described, this update to Just Track facilitates the ability to add integer value when creating an array of objects with the payload of the event. 

In order to parse to tracking services such as firebase, this array of objects is now encoded as a dictionary. 