### PR TITLE
Fixed unstored events

### DIFF
--- a/JustTrack/Classes/JustTrack/Operations/TrackOperation.swift
+++ b/JustTrack/Classes/JustTrack/Operations/TrackOperation.swift
@@ -21,16 +21,15 @@ class TrackOperation: Operation {
         self.tracker = tracker
         self.eventKey = "\(event.name)_ON_\(tracker.name)_\(Date().timeIntervalSince1970)"
         super.init()
+        
+        // Persist the event.
+        saveEvent(event, key: eventKey)
     }
     
     // MARK: - Operation lifecycle
     
     override func main() {
-        guard !isCancelled else { return }
-        
-        // Persist the event.
         // Delete it before posting if the operation was cancelled while persisting the event.
-        saveEvent(event, key: eventKey)
         guard !isCancelled else {
             deleteEvent(eventKey)
             return


### PR DESCRIPTION
Currently, we are saving events in `TrackOperation` `main` function. the `TrackOperation` inherited from [Operation](https://developer.apple.com/documentation/foundation/operation). the `main` function is executed only when the operation is ready to execute-  `OperationQueue` priority.

So if we will send multiple `trackEvent` only the current executed event will be stored but it even doesn’t make sense to store only current because this is already executing.

Simplified sample:
```
final class TrackOperation: Operation {
    private let id: String
    init(id: String) {
        self.id = id
    }
    override func main() {
        print("store \(id)")
        sleep(5)
    }
}

let queue = OperationQueue()
queue.maxConcurrentOperationCount = 1

queue.addOperation(TrackOperation(id: "1"))
queue.addOperation(TrackOperation(id: "2"))
queue.addOperation(TrackOperation(id: "3"))
queue.cancelAllOperations()

Output:
store 1
```
PS: better improvements will be done in further PRs, this is only to fix the issue.